### PR TITLE
[ci] Create remote app directories before upload in deploy workflows

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -43,6 +43,7 @@ jobs:
 
       - name: Upload jar
         run: |
+          ssh -i ~/.ssh/deploy_key ${{ vars.EC2_USER }}@${{ vars.EC2_HOST }} 'mkdir -p apps/backend'
           scp -i ~/.ssh/deploy_key \
             SpringBootBrawlStars/app.jar \
             ${{ vars.EC2_USER }}@${{ vars.EC2_HOST }}:apps/backend/app.jar.new

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -52,6 +52,7 @@ jobs:
 
       - name: Upload build
         run: |
+          ssh -i ~/.ssh/deploy_key ${{ vars.EC2_USER }}@${{ vars.EC2_HOST }} 'mkdir -p apps'
           scp -i ~/.ssh/deploy_key \
             /tmp/frontend.tar.gz \
             ${{ vars.EC2_USER }}@${{ vars.EC2_HOST }}:apps/frontend.tar.gz


### PR DESCRIPTION
배포 워크플로우가 scp 전에 `mkdir -p`로 EC2의 대상 디렉토리를 생성하도록 보강. `apps/backend` 미존재로 인한 scp 실패(dest open: No such file or directory) 방지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UB4PrgtLWjRUZzz1ugyruG